### PR TITLE
feat: publish Done email client blog series

### DIFF
--- a/src/content/blog/done-building-with-rust-graphrag-and-mcp.md
+++ b/src/content/blog/done-building-with-rust-graphrag-and-mcp.md
@@ -1,0 +1,201 @@
+---
+title: "Building Done: Rust, GraphRAG, and the Complexity You Don't See"
+date: "2026-03-26"
+description: "Technical deep dive into building an email client with Tauri, SvelteKit, SurrealDB, GraphRAG, and MCP. Gmail sync is harder than you think."
+---
+
+In the [first post](/blog/done-why-i-built-my-own-email-client), I explained why I started building Done: an email client designed around understanding, not just speed. This post is the technical deep dive. How the system actually works, where the complexity hides, and why "just a Gmail wrapper" is the wrong mental model.
+
+## Architecture Overview
+
+Done is a crate-heavy Rust workspace behind a SvelteKit UI. At a high level:
+
+```
+┌─────────────────────────────────────────────┐
+│         SvelteKit Frontend (Svelte 5)       │
+│  keyboard-first UI, inbox, graph, search    │
+├─────────────────────────────────────────────┤
+│              Tauri 2 Bridge                 │
+│        (IPC commands, event system)         │
+├─────────────────────────────────────────────┤
+│              Rust Backend                   │
+│  ┌──────────┬───────────┬────────────────┐  │
+│  │  Gmail   │ SurrealDB │  Pipeline      │  │
+│  │  Sync    │ (local    │  triage →      │  │
+│  │  Engine  │  RocksDB) │  graph + emb.  │  │
+│  └──────────┴───────────┴────────────────┘  │
+│  ┌──────────────────────────────────────┐   │
+│  │  Job queue (apalis) · multi-account  │   │
+│  └──────────────────────────────────────┘   │
+├─────────────────────────────────────────────┤
+│              MCP Server (local HTTP)        │
+│     thread tools for authenticated agents   │
+└─────────────────────────────────────────────┘
+```
+
+The Rust backend does the heavy lifting: syncing Gmail accounts, storing mail and graph data locally in SurrealDB, running triage and the extraction pipeline, and exposing operations through both Tauri commands and a local MCP server. The SvelteKit frontend talks to Rust through Tauri's IPC bridge.
+
+## Choosing Tauri Over Electron
+
+This was an easy decision. Electron ships an entire Chromium instance. For an app you keep open all day, that's 200+ MB of RAM before you've loaded a single email. Tauri uses the system's native webview and a Rust backend:
+
+- **Memory:** Done idles at ~80 MB. A comparable Electron app would be 300+.
+- **Binary size:** ~15 MB versus 150+ MB for Electron.
+- **Backend performance:** Rust's concurrency model is a good fit for parallel email fetching, parsing, and graph operations.
+- **Security:** Tauri's permission model is stricter by default. The frontend can only call explicitly exposed Rust commands.
+
+The tradeoff is ecosystem maturity. Electron has ten years of battle-tested patterns. Tauri's plugin ecosystem is younger, and some things that are trivial in Electron (system tray, notifications, auto-updates) take more manual work. Still worth it for an always-on app.
+
+## The Gmail Sync Problem
+
+This is where the "just a wrapper" idea falls apart. Gmail's API is powerful but opinionated, and reliable sync on top of it is hard. Done supports multiple Gmail accounts, and each one multiplies the edge cases.
+
+### Initial Sync
+
+The first time you connect an account, Done needs to pull thread history. It lists threads in pages (100 IDs per page), then fetches each thread's messages. For an account with 50,000 emails, that's:
+
+1. Hundreds of list requests
+2. Tens of thousands of message/thread fetches
+3. Gmail quota limits that punish naive sequential loops
+
+Done parallelizes work with Tokio and throttles requests so we stay inside Gmail's rate limits. Initial sync for a heavy inbox still takes minutes, not seconds, and multi-account makes that cost additive.
+
+But speed isn't the hard part. Data consistency is.
+
+### Incremental Sync
+
+After the initial pull, Done uses Gmail's `history.list` endpoint with a stored history ID to fetch only changes: messages added, labels changed, threads updated. A background job queue (apalis) drives periodic sync and other work. We do not use Google Cloud Pub/Sub. Polling plus history IDs is less glamorous than push, but it's reliable and doesn't need a public webhook endpoint for a desktop app.
+
+Sounds clean. In practice:
+
+- **History IDs expire.** Gmail only keeps history for a limited window. If Done hasn't synced in a while, the history ID may be invalid, and you need to fall back to a full re-sync reconciliation.
+- **Label changes are tricky.** Gmail's label system is more complex than folders. A message can have multiple labels, and "removing from inbox" is actually "removing the INBOX label," not moving the message. Done's local model has to mirror that.
+- **Drafts are mutable.** Unlike sent messages, drafts change. The same draft ID can have completely different content between syncs.
+- **Batch operations on Gmail's side.** If a user archives 500 messages on Gmail's web client, Done receives a flood of history events. Processing those without hammering the UI needs careful batching and optimistic local updates with rollback on failure.
+
+### Offline, Retention, and Conflict Resolution
+
+Done stores emails locally in SurrealDB (embedded RocksDB). You can read, search, and triage offline. When you come back online, local actions need to sync back to Gmail:
+
+- You archived an email locally. Did someone also reply to that thread while you were offline? The archive still applies, but the thread now has new messages.
+- You labeled an email locally. Did someone else (or a Gmail filter) also modify labels? Labels are additive, so this usually merges cleanly, but edge cases exist.
+
+For archived mail, a body retention policy can trim full HTML bodies over time to keep the local database lean. When you need the full content again, Done re-fetches the thread from Gmail. Agents can do the same through an MCP tool.
+
+The current approach is last-write-wins for label operations with thread-level awareness for structural changes. Not perfect, but it handles most real-world scenarios without user intervention.
+
+## The RAG Extraction Pipeline
+
+This is the heart of what makes Done different, and the most complex subsystem to build.
+
+### Why GraphRAG, Not Vector Search
+
+Standard RAG works like this: chunk documents, embed chunks, store vectors, query with similarity search. It works well for "find me emails about X" but poorly for "what commitments do I have with Acme Corp this quarter?"
+
+The second query needs relationships between entities across multiple emails. Vector similarity will find emails that mention Acme Corp, but it won't connect a deadline in email A with a deliverable in email B with a person introduced in email C.
+
+GraphRAG builds a knowledge graph during indexing:
+
+```
+[Manuel] --sent_to--> [Marco]
+[Marco] --works_at--> [Acme Corp]
+[Email #1241] --mentions--> [Project Alpha]
+[Project Alpha] --has_deadline--> [2026-04-15]
+[Email #1307] --contains_commitment--> [Deliver prototype]
+[Deliver prototype] --related_to--> [Project Alpha]
+```
+
+When you query "what did I promise Acme?", the system traverses the graph from Acme Corp through related projects, commitments, and deadlines. The answer is assembled from multiple emails without any single email containing the full picture. Done also supports multiple query modes (local, global, hybrid, mix, naive) so retrieval can lean on graph structure, vectors, or both.
+
+### Triage Before Extraction
+
+Not every email deserves a full LLM pass. Before extraction, a triage layer classifies messages into categories like direct communication, knowledge-rich content, transactional mail, and noise. Heuristics run first. Graph context can refine low-confidence decisions. Only messages that need it get embedded, summarized, or written into the knowledge graph. That filter is what makes GraphRAG affordable on a real inbox.
+
+### The Extraction Pipeline
+
+Emails that pass triage go through a multi-stage pipeline.
+
+**Stage 1: Parsing.** Strip HTML, extract plain text, identify quoted text (previous replies), parse headers. Email HTML is notoriously inconsistent. Every client generates different markup. Custom parsers and heuristics extract clean text for the model.
+
+**Stage 2: Entity extraction.** Identify people, organizations, dates, monetary amounts, project names, and action items. Extraction runs through a pluggable chat provider: Ollama for fully local work, or cloud providers (Gemini, Groq, Cerebras, and others) when you opt in. Token usage and cost are tracked per call so you can see what GraphRAG actually costs.
+
+**Stage 3: Relationship mapping.** Connect extracted entities to each other and to existing graph nodes. If Marco from Acme Corp was already in the graph, the new email's mentions get linked to the existing entity rather than creating duplicates. Entity resolution (deciding that "Marco," "Marco R.," and "marco.rossi@acme.com" are the same person) is harder than it sounds.
+
+**Stage 4: Graph insertion.** Entities and relationships land in SurrealDB's graph tables alongside email records. One local database holds mail, vectors, graph, jobs, and settings.
+
+**Stage 5: Embedding.** Email chunks and entity descriptions get embedded for hybrid retrieval: graph traversal for structured queries, vector similarity for fuzzy ones. Embeddings default to local models via fastembed, with an optional remote embedder.
+
+### Performance Considerations
+
+Running an LLM extraction pipeline on every email would be ruinous. What makes it viable:
+
+- **Triage first.** Noise never reaches the expensive stages.
+- **Background jobs.** Sync, embedding, graph work, retention, and triage run on a job queue you can pause and resume from the UI.
+- **Prioritized processing.** Inbox and high-value mail jump the queue. Bulk historical sync runs in the background.
+- **Incremental updates.** New emails add to the graph. They don't trigger a full rebuild.
+- **Caching.** Re-synced messages skip extraction unless content changed.
+
+On a modern laptop, background indexing is fast enough that you don't notice it during normal use. Initial indexing of a large inbox still takes a while. That's the real cost of understanding your mail.
+
+## The MCP Server
+
+This is the feature that points furthest forward, with a more modest surface area than the hype usually implies.
+
+Done runs a local MCP server (HTTP/SSE on localhost, configurable port, disabled by default). Agents authenticate with API keys and get an explicit permission set. Every write action is attributed to a user or agent in an activity log.
+
+Through MCP today, an assistant can:
+
+- List threads by label (inbox, starred, etc.) across accounts
+- Read thread and email content, including re-fetching trimmed bodies
+- List labels for an account
+- Mark as read, archive / unarchive, apply labels
+- Snooze and unsnooze threads
+
+What it does _not_ expose yet: natural-language GraphRAG search, compose/send, or direct graph queries. Those live in the app UI today. The next step is opening graph and search tools to agents so a briefing like "what needs my attention today?" can be assembled without switching windows.
+
+What already works well is composition of primitives. A morning workflow with a connected agent:
+
+1. List inbox threads across accounts
+2. Pull full content for the ones that look important
+3. Archive or snooze the rest with permission
+4. Leave a trail in the activity log so I can see what the agent did
+
+The MCP server means Done isn't limited to what I build into the UI. Custom triage bots, CRM glue, or follow-up systems can sit on the same local data plane, with auth and an audit trail.
+
+## The SvelteKit Frontend
+
+The frontend is keyboard-first on purpose. Superhuman proved that pattern works for email. I borrowed the principle:
+
+- **Single-key actions.** Archive, reply, navigate, search, all without reaching for the mouse.
+- **Command palette.** `Cmd+K` for labels, account switching, settings, and power actions.
+- **Split views.** Thread list and message content, plus dedicated routes for archive, sent, search, graph, activity, and settings.
+- **Light and dark themes.** System preference by default. Your choice either way.
+
+Svelte 5's reactivity keeps the UI responsive without a virtual DOM tax. State changes from the Rust backend (new mail, sync status, job progress) flow through Tauri's event system into rune-based stores. Optimistic archive/unarchive updates the UI immediately and rolls back if Gmail rejects the action. There's also an AI writing assistant in compose for drafting replies without leaving the client.
+
+## What This Stack Looks Like in Practice
+
+A typical flow when new mail arrives:
+
+1. The job queue wakes the sync worker for each connected account
+2. Rust calls Gmail `history.list` from the last history ID (or falls back to reconciliation)
+3. New messages are parsed and stored in SurrealDB
+4. Tauri emits events. The SvelteKit UI updates the thread list
+5. Background: triage classifies the mail. Embedding and graph jobs run when appropriate
+6. Background: MCP tools see the same storage. Agents and UI share one source of truth
+
+Steps 1 through 4 feel near-instant for a small delta. Graph and embedding work finish in the background depending on provider, triage outcome, and how deep the backlog is.
+
+## Series
+
+1. [Why I Built My Own Email Client](/blog/done-why-i-built-my-own-email-client)
+2. **This post:** architecture, Gmail sync, GraphRAG, MCP
+3. [What Building an Email Client Taught Me](/blog/done-lessons-learned)
+
+## Coming Up
+
+In the [final post](/blog/done-lessons-learned), I'll talk about what surprised me most during this build, the complexities I underestimated, and where Done is heading next.
+
+---
+
+_If you're building with Tauri, GraphRAG, or MCP, I'd love to hear about your experience. Find me on [Twitter](https://x.com/iltumio) or [LinkedIn](https://linkedin.com/in/manuel-tumiati)._

--- a/src/content/blog/done-lessons-learned.md
+++ b/src/content/blog/done-lessons-learned.md
@@ -1,0 +1,151 @@
+---
+title: "What Building an Email Client Taught Me"
+date: "2026-03-27"
+description: "Underestimated complexities, surprising lessons, and honest notes from building an email client from scratch."
+---
+
+In [part one](/blog/done-why-i-built-my-own-email-client), I explained why I built Done. In [part two](/blog/done-building-with-rust-graphrag-and-mcp), I walked through the technical architecture. This final post is about what I didn't expect: the lessons that only show up when you actually try to build something that seems simple on the surface.
+
+## "It's Just a Gmail Wrapper"
+
+I said this to a friend when I started. He laughed. He was right to.
+
+The mental model of an email client is deceptively simple: fetch emails, show them in a list, let the user reply. Three API calls and some HTML. Anyone who's built CRUD apps might look at email and think it's the same thing with different data.
+
+It's not. Email is one of the oldest, most complex, and most inconsistent protocols still in daily use. Building a client that feels good (not just one that works) means solving problems across networking, data modeling, NLP, UI performance, and distributed systems at the same time.
+
+Here's what I underestimated, in order of how badly.
+
+## 1. Email HTML Is a War Crime
+
+I knew email HTML was bad. I didn't know it was _this_ bad.
+
+Every email client generates different HTML. Outlook uses Word's rendering engine (yes, Microsoft Word) to generate HTML emails, which means you get `<table>` layouts, `mso-` prefixed CSS properties, and conditional comments like `<!--[if mso]>`. Gmail strips most CSS and rewrites class names. Apple Mail is relatively sane but adds its own quirks.
+
+When Done receives an email, it needs to:
+
+1. Parse the HTML safely (emails can contain malicious scripts)
+2. Extract readable plain text for the RAG pipeline
+3. Render the original HTML faithfully in the UI
+4. Handle inline images, CID-referenced attachments, and base64-encoded content
+
+I spent two weeks just on email parsing. The sanitization library I started with broke legitimate formatting in half the emails I tested. I ended up writing a custom parser that preserves visual structure while stripping anything executable. It's one of the least glamorous pieces of the codebase and one of the most critical.
+
+## 2. Entity Resolution Is an Open Research Problem
+
+The RAG extraction pipeline identifies entities in emails: people, companies, projects, dates. Identifying entities is the easy part. Resolving them is where it gets hard.
+
+Consider these fragments from different emails:
+
+- "Marco will send the updated contract"
+- "Hi Manuel, as discussed with M. Rossi..."
+- "marco.rossi@acme.com has shared a document"
+- "The Acme team confirmed the timeline"
+
+These all reference the same person. A human sees that instantly. An extraction pipeline sees four potentially different entities. Multiply that across thousands of emails with hundreds of contacts and you're facing a combinatorial matching problem.
+
+My current approach uses a multi-signal scoring system:
+
+- Email address matching (strongest signal)
+- Name similarity (fuzzy matching with nickname awareness)
+- Co-occurrence patterns (entities that frequently appear in the same threads)
+- Organizational context (if two names share a company domain, they're more likely related)
+
+It works well for about 90% of cases. The remaining 10% includes common first names across different organizations, people who change companies (and email addresses), and email aliases. I'm still iterating on this.
+
+The lesson: any system that claims to "understand" unstructured text is actually solving a stack of ambiguity problems, each one deeper than the last.
+
+## 3. Sync Is a Distributed Systems Problem
+
+I covered the Gmail sync engine in the [technical post](/blog/done-building-with-rust-graphrag-and-mcp), but I want to emphasize something: email sync is distributed systems in disguise.
+
+You have two sources of truth, the Gmail server and the local SurrealDB database, and they can diverge. Every operation (read, archive, label, delete) needs to be reflected in both places, and conflicts need resolution. Multi-account multiplies the problem. Each account is its own consistency domain with its own history ID, tokens, and rate limits.
+
+This is the same class of problem that CRDTs, operational transforms, and distributed databases solve. Except Gmail's API isn't designed as a distributed system primitive. It's a request-response API with eventual consistency baked in at Google's end.
+
+Things I learned the hard way:
+
+- **Never trust timestamps for ordering.** Gmail's internal timestamps and the timestamps in email headers can disagree. Use Gmail's history IDs for ordering sync events.
+- **Idempotency is everything.** Network failures during sync mean you'll replay operations. Every sync operation needs to be safe to apply twice.
+- **Batch carefully.** Gmail's batch API has a 100-request limit per batch and different rate limits than individual requests. Optimizing batch composition is its own subproblem.
+- **Test with real inboxes.** Synthetic test data doesn't capture the chaos of real-world email. Forwarded messages, bounced emails, calendar invites embedded in threads, mailing list digests: all edge cases that break assumptions.
+- **Optimistic UI needs a real rollback path.** Archiving should feel instant. If Gmail rejects the change, the UI has to put the thread back without lying to the user.
+
+## 4. "Fast Enough" Requires Constant Attention
+
+An email client is an always-on application. Users notice latency in ways they don't notice in a web app they visit occasionally. If the thread list takes 200ms to update after archiving, it feels broken. If search takes more than a second, it feels slow.
+
+Performance isn't a feature you add at the end. It's a constraint that shapes every architectural decision:
+
+- Local queries need schemas designed for email access patterns. Filtering by label + account + date range + read status, sorted by date descending, has to stay fast at 50,000+ messages, including after body retention trims archived content.
+- The knowledge graph can't block the UI. Triage, embedding, and graph jobs run on a background queue (apalis). The UI never waits for extraction. You can pause and resume that work from settings when the machine needs a break.
+- Rendering email threads is surprisingly expensive. A thread with 30 messages, each with different HTML structures, inline images, and quoted text folding, needs virtualization and lazy loading to stay smooth.
+- Memory matters. A user with 100,000 emails stored locally can't have all of them in memory. Done pages message bodies and can drop full HTML for old archived mail until you open them again.
+
+Rust helps a lot here. The language forces you to think about ownership, allocation, and concurrency from the start. Problems that would show up as GC pauses or memory leaks in JavaScript surface as compile-time errors in Rust. The tradeoff is development speed. Everything takes longer to write.
+
+## 5. The MCP Integration Changed How I Think About Apps
+
+I built the MCP server as an experiment. It became the feature that changed my mental model of what an application should be.
+
+Traditional app design assumes the user interacts through the app's UI. MCP breaks that assumption. Suddenly the app isn't only a visual interface. It's a data service that any intelligent agent can query and act on, with permissions and an activity log so you know who did what.
+
+A few implications beyond email:
+
+- Apps become tools, not destinations. Instead of switching to your email client to check something, your AI assistant queries it in context.
+- Composition beats features. Instead of building every possible workflow into the email client, expose primitives (list threads, read, archive, label, snooze) and let agents compose them.
+- The UI becomes optional for some flows. "Snooze that Acme thread until Monday" doesn't need a visual interface once an agent has the right tools.
+
+I think the next generation of productivity software will look like this: a core data engine with a thin UI layer and a rich programmatic interface. The UI handles what humans do well (reading, browsing, composing). The programmatic interface handles what AI does well (searching, summarizing, scheduling, connecting dots).
+
+Done isn't fully there yet. MCP today is strong on actions and read access. GraphRAG search still lives mainly in the app. Building the server still showed me the direction.
+
+## 6. Scope Is the Hardest Problem
+
+Every week I think of something else Done "should" do. Calendar integration. Contact management. Email templates. Undo send. Read receipts. Deeper CRM-style contact views.
+
+Each feature is individually reasonable. Together, they represent years of work. The hardest engineering decision I make on Done isn't technical. It's deciding what _not_ to build.
+
+My filter: does this feature help you get things done, or does it just make the client more "complete"? Multi-account support helped, so I built it, even though it doubled sync complexity. Body retention helped keep large inboxes usable. Custom email signatures don't. They're a box-checking feature.
+
+This is harder than it sounds because every email client comparison article has a feature matrix, and every missing checkbox feels like a competitive disadvantage. But Done isn't trying to be a better Superhuman. It's trying to be a different kind of tool.
+
+## What's Next
+
+Done is past the "does it boot?" stage. I use it daily with multiple accounts, GraphRAG search in-app, and agents on MCP. Some things I'm still pushing on:
+
+- **Improving entity resolution.** The ~90% accuracy rate needs to get to 98%+ for the knowledge graph to be truly reliable.
+- **Smarter triage.** Heuristics and graph context already filter noise before the LLM. I want triage to learn from my behavior over time.
+- **Richer MCP tools.** Read/archive/label/snooze are live. Next is exposing GraphRAG and graph queries so agents can answer "find unresolved threads with people I haven't replied to in over a week" without the UI.
+- **Compose and send for agents.** Writing assistance already lives in the compose UI. Wiring safe, permissioned send paths into MCP is the careful step after that.
+
+I'm not sure if Done will ever be a product other people use. It might stay as my personal tool. But the patterns I've learned (GraphRAG for relational data, MCP for app-as-service, Tauri for performant desktop apps, local-first storage with optional cloud LLMs) apply far beyond email.
+
+## The Honest Summary
+
+Building an email client from scratch was harder than I expected, took longer than I planned, and taught me more than I anticipated:
+
+| What I Expected                       | What Actually Happened                             |
+| ------------------------------------- | -------------------------------------------------- |
+| Gmail API is straightforward          | Sync is a distributed systems problem              |
+| Email parsing is boring but simple    | Email HTML is the worst HTML on the internet       |
+| Entity extraction is a solved problem | Entity _resolution_ is an open research problem    |
+| Performance can be optimized later    | Performance shapes architecture from day one       |
+| MCP is a nice-to-have experiment      | MCP changed my mental model of what apps should be |
+| Scope management is about discipline  | Scope management is the actual hard problem        |
+
+If you're considering building a desktop app with Tauri, experimenting with GraphRAG, or integrating MCP into your tools, do it. Each of these is ready for real use. Just don't underestimate the domain you're applying them to.
+
+Email seems simple. It isn't. But that's what makes it interesting.
+
+---
+
+## Series
+
+1. [Why I Built My Own Email Client](/blog/done-why-i-built-my-own-email-client)
+2. [Building Done: Rust, GraphRAG, and the Complexity You Don't See](/blog/done-building-with-rust-graphrag-and-mcp)
+3. **This post:** lessons learned
+
+---
+
+_This is the final post in the Done series. If you're working on similar problems (email clients, GraphRAG, MCP integrations, or Tauri apps), I'd love to compare notes. Find me on [Twitter](https://x.com/iltumio) or [LinkedIn](https://linkedin.com/in/manuel-tumiati)._

--- a/src/content/blog/done-why-i-built-my-own-email-client.md
+++ b/src/content/blog/done-why-i-built-my-own-email-client.md
@@ -1,0 +1,71 @@
+---
+title: "Why I Built My Own Email Client"
+date: "2026-03-25"
+description: "Superhuman and Spark are great. But I wanted an email client that thinks the way I do. So I built Done."
+---
+
+I get around 150 emails a day. Not because I'm important. Because email is where work happens, whether you want it to or not. Feature requests from clients, contract PDFs, CI/CD notifications, newsletters I swore I'd read, and the occasional email that actually matters buried somewhere in the middle.
+
+I've tried everything. Gmail's native client, Spark, Superhuman. They all share the same assumption: the way to fix email is to make it faster. Better keyboard shortcuts. Snappier UI. Split inboxes.
+
+But speed isn't my problem. Knowing what to do next is my problem.
+
+## The Superhuman Paradox
+
+Superhuman is good software. The keyboard-first UX is fast. The design is clean. After months of using it, though, I realized something: Superhuman makes me faster at processing email. It doesn't make me better at _acting_ on it.
+
+I'd fly through my inbox at 6 AM, hit Inbox Zero by 6:15, and then spend the rest of the morning trying to remember which email had the contract I needed to review, what the client's deadline was, and whether I'd already replied to that thread from last Tuesday.
+
+Spark has a similar issue. Smart categorization helps with triage, but the categories are generic. "Newsletters" and "Notifications" are easy to sort. The hard part is the emails that require judgment, context, and follow-up. Those still sit in a pile labeled "Personal."
+
+## What I Actually Need
+
+I started writing down what I wished my email client could do:
+
+1. **Understand context, not just keywords.** If I search for "the contract Marco sent about the new project," I want results even if none of those exact words appear in the email.
+2. **Surface what matters.** Not by sender importance or read/unread status, but by understanding what's actionable and what's noise.
+3. **Remember things I forget.** If a client mentioned a deadline three emails ago, I shouldn't have to dig for it.
+4. **Work with my tools, not replace them.** My workflow already includes AI assistants, task managers, and calendars. My email client should plug into that ecosystem, not compete with it.
+5. **Keep my data under my control.** Email is my business. I want it stored on my machine, not locked into someone else's cloud product. And when AI touches it, I want that to be my choice.
+
+None of the existing clients checked all five boxes. Superhuman nails keyboard UX but has no real semantic understanding. Spark does some smart sorting but is cloud-dependent. Apple Mail is private but dumb. And Gmail is... Gmail.
+
+## The Experiment
+
+I'm a CTO who builds with Rust and blockchain for a living. I spend my days on cryptographic protocols, distributed systems, and zero-knowledge proofs. Building an email client wasn't on my roadmap.
+
+But two technologies had been sitting in my "want to build something with this" list for months.
+
+**GraphRAG** is retrieval-augmented generation backed by a knowledge graph instead of flat vector search. Microsoft Research published their approach in 2024, and the idea stuck with me. Instead of just embedding documents and doing similarity search, you build a graph of entities, relationships, and concepts. Retrieval gets richer because the system understands how things connect, not only how they look in vector space.
+
+**MCP (Model Context Protocol)** is Anthropic's protocol for giving AI models access to external tools and data sources. Instead of the model hallucinating about your emails, it can actually read them, act on them, and operate through a structured interface.
+
+An email client felt like a good proving ground for both. Emails are inherently relational: people, companies, projects, threads, attachments, dates, action items. That's a graph, not a flat list. And MCP meant I could make email a first-class tool for AI assistants rather than something you alt-tab away from.
+
+## Done
+
+So I started building Done. The name is the goal: an email client that helps you get things _done_, not just get through your inbox.
+
+The stack is Tauri 2 with a SvelteKit frontend (Svelte 5) and a Rust backend. Emails sync from Gmail's API, including multi-account support, and live in a local SurrealDB database. A triage layer filters noise before the expensive work starts. The GraphRAG pipeline extracts entities and relationships into a local knowledge graph. Embeddings can run fully local. LLM extraction can run on Ollama on your machine or on cloud providers you configure. The whole thing also exposes a local MCP server so AI agents can read threads, archive, label, and snooze through a standard protocol.
+
+The idea is simple. Your email client should understand your email the way you do: not as a list of messages sorted by date, but as a web of conversations, people, commitments, and context.
+
+It's a working product I use daily. Rough around the edges in places, but it already does things no other email client can. Example: answering "what did I promise to deliver to the Acme team this month?" by traversing the knowledge graph instead of doing keyword search.
+
+## This Series
+
+This is the first post in a three-part series about building Done:
+
+1. **This post:** why I built it and what I'm trying to solve
+2. **[Building Done](/blog/done-building-with-rust-graphrag-and-mcp):** the technical deep dive into Tauri, GraphRAG, Gmail sync, and the extraction pipeline
+3. **[Lessons learned](/blog/done-lessons-learned):** what surprised me, what I underestimated, and where this is going
+
+If you've ever thought "I could build a better email client," I hope this series gives you a realistic picture of what that actually involves. It's harder than it looks.
+
+## Coming Up
+
+Next: [Building Done: Rust, GraphRAG, and the Complexity You Don't See](/blog/done-building-with-rust-graphrag-and-mcp). How the system actually works, why Gmail sync is a distributed systems problem, and what GraphRAG looks like on a local email graph.
+
+---
+
+_Building something interesting? Find me on [Twitter](https://x.com/iltumio) or [LinkedIn](https://linkedin.com/in/manuel-tumiati)._

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -6,7 +6,9 @@ import CompactHeader from '../../components/compact-header/CompactHeader.astro';
 export const prerender = true;
 
 export async function getStaticPaths() {
+  const isDev = import.meta.env.DEV;
   const posts = await getCollection('blog', (post) => {
+    if (isDev) return post.data.date <= new Date();
     return !post.data.draft && post.data.date <= new Date();
   });
   return posts.map((post) => ({

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,8 +5,10 @@ import { getCollection } from 'astro:content';
 
 export const prerender = true;
 
+const isDev = import.meta.env.DEV;
 const now = new Date();
 const posts = (await getCollection('blog', (post) => {
+	if (isDev) return post.data.date <= now;
 	return !post.data.draft && post.data.date <= now;
 })).sort(
 	(a, b) => b.data.date.valueOf() - a.data.date.valueOf()
@@ -18,8 +20,8 @@ const gridCols = posts.length >= 3 ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
 ---
 
 <Layout
-  title="Web3 & Blockchain Blog | Manuel Tumiati"
-  description="Technical insights and analysis on Web3 development, blockchain architecture, self-sovereign identity, and zero-knowledge proofs by Manuel Tumiati."
+  title="Blog | Manuel Tumiati"
+  description="Technical insights on Web3, blockchain, digital identity, systems engineering, and the tools I build — by Manuel Tumiati."
   breadcrumbs={[
     { name: "Home", url: "/" },
     { name: "Blog", url: "/blog" },
@@ -33,7 +35,7 @@ const gridCols = posts.length >= 3 ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
         <div class="mb-12 text-center md:text-left">
           <h1 class="text-4xl lg:text-5xl font-extrabold text-gray-900 dark:text-white mb-4 tracking-tight">Blog</h1>
           <p class="text-xl text-gray-600 dark:text-gray-400 max-w-2xl">
-            Thoughts, insights, and updates from my journey in Web3 and blockchain engineering.
+            Engineering notes on Web3, identity, and the systems I build — from blockchain protocols to desktop apps.
           </p>
         </div>
 
@@ -55,6 +57,11 @@ const gridCols = posts.length >= 3 ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
                           day: "numeric",
                         })}
                       </time>
+                      {post.data.draft && (
+                        <span class="ml-2 px-2 py-0.5 text-xs font-semibold rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+                          Draft
+                        </span>
+                      )}
                     </div>
                     <h2 class="text-xl font-bold text-gray-900 dark:text-white mb-3 group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors line-clamp-2">
                       {post.data.title}


### PR DESCRIPTION
Add a three-part series on building Done (why, architecture, lessons), aligned with the current Tauri/SvelteKit/SurrealDB/MCP stack, and show draft posts in local blog listings during development.