### PR TITLE
docs: refresh README for the current Astro stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,44 @@
-# Manuel Tumiati 🧑‍💻
-## Web3 CTO & Blockchain Engineer
+# Manuel Tumiati
 
-I am an enthusiastic software engineer with a specialization in blockchain technology, covering various aspects ranging from architecture design to smart contract development. My passion lies in leveraging the power of blockchain to create innovative solutions and drive technological advancements.
+**Web3 CTO & Blockchain Engineer**
 
-## ENS
-`iltumio.eth`
+Personal website and blog of [Manuel Tumiati](https://iltumio.dev) — Co-founder & CTO at [Zyphe](https://zyphe.com). I work on blockchain architecture, smart contracts, self-sovereign identity, and zero-knowledge proofs.
 
-## Social
+## Links
 
+- Site: [iltumio.dev](https://iltumio.dev)
+- ENS: `iltumio.eth`
+- [GitHub](https://github.com/iltumio)
 - [LinkedIn](https://linkedin.com/in/manuel-tumiati)
-- [Twitter](https://x.com/iltumio)
-- [Website](https://iltumio.dev)
-- [Decentralized Website](https://iltumio.eth.limo)
+- [X](https://x.com/iltumio)
+- Blog: [iltumio.dev/blog](https://iltumio.dev/blog)
+- RSS: [iltumio.dev/rss.xml](https://iltumio.dev/rss.xml)
 
----
+## Stack
+
+- [Astro](https://astro.build) with the [Cloudflare adapter](https://docs.astro.build/en/guides/integrations-guide/cloudflare/)
+- [Tailwind CSS](https://tailwindcss.com)
+- Markdown blog via [Astro content collections](https://docs.astro.build/en/guides/content-collections/) (`src/content/blog`)
+- Deployed to Cloudflare Pages
 
 ## Development
 
+Requires [Bun](https://bun.sh) and Node.js 22+.
+
+```bash
+bun install
+bun dev
 ```
-pnpm dev
-```
+
 ## Production
 
-The production build should generate the client and server modules by running both client and server build commands. Additionally, the build command will use Typescript run a type check on the source.
+```bash
+bun run build
+bun run preview
+```
 
-```
-pnpm build
-```
+`build` compiles the site for Cloudflare. `preview` serves that build locally with Wrangler.
 
 ## Credits
+
 Made with ♥️ by Manuel Tumiati
-
-## Static Site Generator (Node.js)
-
-```
-pnpm build.server
-```


### PR DESCRIPTION
## Summary
- Rewrite the README so it matches the current site: Astro 5, Bun, Cloudflare Pages.
- Drop leftover Qwik/pnpm/SSG commands (`pnpm build.server`, client/server module wording).
- Add current role, GitHub, blog, and RSS; keep ENS.

## Test plan
- [ ] Skim the README against `package.json` scripts (`dev`, `build`, `preview`).
- [ ] Confirm links (site, blog, RSS, socials) resolve.